### PR TITLE
set the backgroundImage property only if it is available

### DIFF
--- a/controllers/page/backButton.js
+++ b/controllers/page/backButton.js
@@ -1,6 +1,9 @@
 var properties = arguments[0];
 
-$.button.backgroundImage = properties.properties.backgroundImage;
+if (properties.properties.backgroundImage) {
+    $.button.backgroundImage = properties.properties.backgroundImage;
+}
+
 $.button.title = properties.properties.title || L('back');
 $.button.addEventListener('click', properties.properties.callback || function(e) {
     properties.pageflow.back();


### PR DESCRIPTION
if `properties.properties.backgroundImage` is not set, the `backgroundImage property` of `$.button` will still be overwritten. This PR allows to avoid this behavior.
